### PR TITLE
Revamp landing page with agent-native design

### DIFF
--- a/docs/agent-native-landing-scope.md
+++ b/docs/agent-native-landing-scope.md
@@ -1,0 +1,137 @@
+# Scope: Agent-Native Games Messaging on Landing Page
+
+## 1. Document Control
+- Product: `realms-world-site`
+- Date: February 12, 2026
+- Status: Draft (Scoping)
+- Branch: `ponderingdemocritus/agentlp`
+
+## 2. Goal
+Update the landing page to clearly communicate that Realms World is launching an agent that can play all games, and position the ecosystem as agent-native.
+
+## 3. Current State (Code Reality)
+- Homepage composition is in `src/routes/index.tsx` and currently renders:
+  - `IntroSection`
+  - `GamesSection`
+  - `PartnersSection`
+  - `ValueFlowSection`
+  - `TokenomicsSection`
+  - `TreasurySection`
+- Hero copy is in `src/components/sections/IntroSection.tsx`.
+- Featured game carousel is in `src/components/sections/GamesSection.tsx`.
+- Homepage section nav items are defined in `src/components/layout/TopBar.tsx`.
+- Games metadata is centralized in `src/data/games.ts`.
+
+## 4. Scope Options
+
+### Option A: Copy-Only (Fastest)
+Change only homepage messaging to include agent-native positioning.
+
+Deliverables:
+1. Update hero headline/subheadline in `src/components/sections/IntroSection.tsx`.
+2. Update homepage meta description in `src/routes/index.tsx`.
+
+Effort:
+- ~0.5 day including QA.
+
+Pros:
+- Lowest risk, fastest ship.
+
+Limits:
+- No dedicated section explaining what the agent does.
+- No per-game “agent-ready” visibility.
+
+### Option B: Recommended Landing Refresh
+Add dedicated “Agent-Native Games” section and wire it into homepage navigation.
+
+Deliverables:
+1. Add new section component, e.g. `src/components/sections/AgentNativeSection.tsx`.
+2. Insert section in `src/routes/index.tsx` (likely between hero and featured games).
+3. Add section anchor in `src/components/layout/TopBar.tsx` for homepage nav.
+4. Add CTA(s), e.g.:
+  - `Try the Agent` (if route exists)
+  - `Join Waitlist` (if external form exists)
+5. Refresh SEO copy in `src/routes/index.tsx`.
+
+Effort:
+- ~1 to 2 days including responsive polish and QA.
+
+Pros:
+- Clear value narrative.
+- Stronger launch messaging.
+
+Limits:
+- Still no per-game agent status in listing/details.
+
+### Option C: Full Agent-Native Surface (Landing + Games IA)
+Extend Option B with structured agent-support metadata across game surfaces.
+
+Deliverables:
+1. Add field to `Game` type in `src/data/games.ts`, for example:
+   - `agentSupport: "live" | "launching" | "planned"`
+2. Annotate each game entry with agent support state.
+3. Show badge on:
+   - `src/components/sections/GamesSection.tsx`
+   - `src/routes/games/index.tsx`
+   - `src/components/game/GameDetails.tsx`
+4. Optional: Add filter “Agent-ready”.
+
+Effort:
+- ~2 to 3 days including data updates and QA.
+
+Pros:
+- End-to-end clarity.
+- Future-proof for phased game enablement.
+
+Limits:
+- Requires high-confidence status data per game.
+
+## 5. Recommended Slice to Start
+Start with **Option B**:
+1. It is enough to launch the message credibly.
+2. It avoids blocking on precise per-game status data.
+3. Option C can follow without reworking core landing structure.
+
+## 6. Proposed Content Blocks (Option B)
+Section: `Agent-Native Games`
+
+Content pattern:
+1. Claim: “One agent, every game in the Realms ecosystem.”
+2. How it works: short 3-step explanation (discover game -> execute actions -> optimize play).
+3. Launch state: “Launching soon” language with specific CTA.
+4. Trust framing: transparent note that coverage expands over time if needed.
+
+## 7. Dependencies / Inputs Needed
+Before implementation, confirm:
+1. Final launch copy (headline + subheadline + legal-safe claim language).
+2. Agent name/brand label.
+3. CTA destination:
+   - URL/route for product page, or
+   - Waitlist form URL.
+4. Asset availability:
+   - Agent visual (image/video/demo) or use text-first layout.
+5. Whether claim is strictly “all games at launch” or “all games over rollout.”
+
+## 8. Risks and Mitigations
+1. Risk: Overstating “plays all games” before full support.
+   - Mitigation: Use precise launch wording and visible rollout note.
+2. Risk: Added visual media increases page weight.
+   - Mitigation: Keep new section lightweight and lazy-load heavy media.
+3. Risk: Inconsistent game count messaging.
+   - Mitigation: Replace hardcoded “Active Games: 6” in `IntroSection` with derived value from `games` data.
+
+## 9. Acceptance Criteria (Option B Baseline)
+1. Homepage includes a clear `Agent-Native Games` section.
+2. Section appears in homepage navigation and scrolls correctly.
+3. Hero/SEO copy reflects agent launch messaging.
+4. Mobile layout remains readable and functional.
+5. No regression in existing routes: `/`, `/games`, `/games/:slug`.
+
+## 10. Implementation Checklist (When Approved)
+1. Implement section and route insertion.
+2. Update top navigation section map.
+3. Update hero and meta copy.
+4. Run checks:
+   - `pnpm lint`
+   - `pnpm build`
+   - `node --test tests/mobile-fixes.test.mjs tests/seo-mobile-readiness.test.mjs`

--- a/src/components/RealmSceneBackground.tsx
+++ b/src/components/RealmSceneBackground.tsx
@@ -1,0 +1,240 @@
+import { useEffect, useRef } from "react";
+import * as THREE from "three";
+
+function createMobiusStripGeometry(
+  segmentsU: number,
+  segmentsV: number,
+  radius: number,
+  halfWidth: number
+) {
+  const vertexCount = (segmentsU + 1) * (segmentsV + 1);
+  const positions = new Float32Array(vertexCount * 3);
+  const indices: number[] = [];
+
+  let cursor = 0;
+  for (let i = 0; i <= segmentsU; i++) {
+    const u = (i / segmentsU) * Math.PI * 2;
+    const cosU = Math.cos(u);
+    const sinU = Math.sin(u);
+    const cosHalfU = Math.cos(u * 0.5);
+    const sinHalfU = Math.sin(u * 0.5);
+
+    for (let j = 0; j <= segmentsV; j++) {
+      const v = ((j / segmentsV) * 2 - 1) * halfWidth;
+      const radial = radius + v * cosHalfU;
+
+      positions[cursor++] = radial * cosU;
+      positions[cursor++] = v * sinHalfU;
+      positions[cursor++] = radial * sinU;
+    }
+  }
+
+  for (let i = 0; i < segmentsU; i++) {
+    for (let j = 0; j < segmentsV; j++) {
+      const a = i * (segmentsV + 1) + j;
+      const b = a + 1;
+      const c = (i + 1) * (segmentsV + 1) + j;
+      const d = c + 1;
+
+      indices.push(a, c, b);
+      indices.push(b, c, d);
+    }
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+  geometry.setIndex(indices);
+  geometry.computeVertexNormals();
+
+  return geometry;
+}
+
+export function RealmSceneBackground() {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)"
+    ).matches;
+    const isSmallViewport = window.innerWidth < 768;
+
+    // Keep motion subtle on constrained devices.
+    const particleCount = isSmallViewport ? 500 : 1400;
+    const motionScale = prefersReducedMotion ? 0.15 : 1;
+
+    const scene = new THREE.Scene();
+    scene.fog = new THREE.Fog(0x0b0d13, 12, 42);
+
+    const camera = new THREE.PerspectiveCamera(
+      58,
+      window.innerWidth / window.innerHeight,
+      0.1,
+      100
+    );
+    camera.position.set(0, 1.4, 8);
+
+    const renderer = new THREE.WebGLRenderer({
+      antialias: !isSmallViewport,
+      alpha: true,
+      powerPreference: "high-performance",
+    });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 1.5));
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer.setClearColor(0x000000, 0);
+    container.appendChild(renderer.domElement);
+
+    const ambient = new THREE.AmbientLight(0xf4ead8, 0.85);
+    scene.add(ambient);
+
+    const rim = new THREE.DirectionalLight(0xf6cf8b, 1.1);
+    rim.position.set(4, 8, 6);
+    scene.add(rim);
+
+    const fill = new THREE.DirectionalLight(0x9eb4ff, 0.45);
+    fill.position.set(-6, -2, -4);
+    scene.add(fill);
+
+    const starsGeometry = new THREE.BufferGeometry();
+    const starsPosition = new Float32Array(particleCount * 3);
+    const starsColor = new Float32Array(particleCount * 3);
+    const warm = new THREE.Color("#f4ddc0");
+    const cool = new THREE.Color("#88a2ff");
+
+    for (let i = 0; i < particleCount; i++) {
+      const i3 = i * 3;
+      starsPosition[i3] = (Math.random() - 0.5) * 28;
+      starsPosition[i3 + 1] = (Math.random() - 0.5) * 14;
+      starsPosition[i3 + 2] = (Math.random() - 0.5) * 32;
+
+      const mix = Math.random();
+      const tint = warm.clone().lerp(cool, mix);
+      starsColor[i3] = tint.r;
+      starsColor[i3 + 1] = tint.g;
+      starsColor[i3 + 2] = tint.b;
+    }
+
+    starsGeometry.setAttribute(
+      "position",
+      new THREE.BufferAttribute(starsPosition, 3)
+    );
+    starsGeometry.setAttribute("color", new THREE.BufferAttribute(starsColor, 3));
+
+    const starsMaterial = new THREE.PointsMaterial({
+      size: isSmallViewport ? 0.028 : 0.038,
+      transparent: true,
+      opacity: 0.8,
+      depthWrite: false,
+      vertexColors: true,
+      blending: THREE.AdditiveBlending,
+    });
+
+    const stars = new THREE.Points(starsGeometry, starsMaterial);
+    scene.add(stars);
+
+    const centerpieceGroup = new THREE.Group();
+    scene.add(centerpieceGroup);
+
+    const mobiusGeometry = createMobiusStripGeometry(
+      isSmallViewport ? 120 : 180,
+      isSmallViewport ? 12 : 20,
+      2.25,
+      isSmallViewport ? 0.28 : 0.36
+    );
+    const mobiusMaterial = new THREE.MeshStandardMaterial({
+      color: "#d4b07a",
+      emissive: "#251608",
+      roughness: 0.35,
+      metalness: 0.7,
+      transparent: true,
+      opacity: 0.82,
+      side: THREE.DoubleSide,
+    });
+    const mobiusStrip = new THREE.Mesh(mobiusGeometry, mobiusMaterial);
+    const baseRotation = new THREE.Euler(0.82, 0.2, 0.38);
+    mobiusStrip.rotation.copy(baseRotation);
+    centerpieceGroup.add(mobiusStrip);
+
+    const mobiusEdgesGeometry = new THREE.EdgesGeometry(mobiusGeometry, 24);
+    const mobiusEdgesMaterial = new THREE.LineBasicMaterial({
+      color: "#a6bcff",
+      transparent: true,
+      opacity: 0.76,
+    });
+    const mobiusEdges = new THREE.LineSegments(
+      mobiusEdgesGeometry,
+      mobiusEdgesMaterial
+    );
+    mobiusStrip.add(mobiusEdges);
+
+    const pointer = new THREE.Vector2(0, 0);
+    const onPointerMove = (event: PointerEvent) => {
+      pointer.x = (event.clientX / window.innerWidth) * 2 - 1;
+      pointer.y = (event.clientY / window.innerHeight) * 2 - 1;
+    };
+
+    let rafId = 0;
+    const clock = new THREE.Clock();
+    const animate = () => {
+      const elapsed = clock.getElapsedTime();
+      const drift = elapsed * 0.08 * motionScale;
+
+      stars.rotation.y = drift * 0.45;
+      stars.rotation.x = Math.sin(elapsed * 0.23) * 0.04 * motionScale;
+
+      centerpieceGroup.rotation.y = elapsed * 0.2 * motionScale;
+      centerpieceGroup.rotation.z = Math.sin(elapsed * 0.34) * 0.1 * motionScale;
+
+      mobiusStrip.rotation.x =
+        baseRotation.x + Math.sin(elapsed * 0.55) * 0.09 * motionScale;
+      mobiusStrip.rotation.y =
+        baseRotation.y + Math.cos(elapsed * 0.45) * 0.08 * motionScale;
+      mobiusStrip.rotation.z =
+        baseRotation.z + Math.sin(elapsed * 0.75) * 0.07 * motionScale;
+      mobiusStrip.position.y = Math.sin(elapsed * 0.72) * 0.09 * motionScale;
+
+      camera.position.x += (pointer.x * 0.45 - camera.position.x) * 0.035;
+      camera.position.y += (-pointer.y * 0.28 + 1.4 - camera.position.y) * 0.035;
+      camera.lookAt(0, 0, 0);
+
+      renderer.render(scene, camera);
+      rafId = window.requestAnimationFrame(animate);
+    };
+    animate();
+
+    const onResize = () => {
+      camera.aspect = window.innerWidth / window.innerHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(window.innerWidth, window.innerHeight);
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio, 1.5));
+    };
+
+    window.addEventListener("resize", onResize);
+    window.addEventListener("pointermove", onPointerMove);
+
+    return () => {
+      window.cancelAnimationFrame(rafId);
+      window.removeEventListener("resize", onResize);
+      window.removeEventListener("pointermove", onPointerMove);
+
+      starsGeometry.dispose();
+      starsMaterial.dispose();
+      mobiusGeometry.dispose();
+      mobiusMaterial.dispose();
+      mobiusEdgesGeometry.dispose();
+      mobiusEdgesMaterial.dispose();
+      renderer.dispose();
+      container.removeChild(renderer.domElement);
+    };
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      aria-hidden="true"
+      className="absolute inset-0 pointer-events-none"
+    />
+  );
+}

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -1,11 +1,7 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { motion, useScroll, useTransform } from "framer-motion";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { socials } from "@/data/socials";
 import { ModeToggle } from "@/components/ui/mode-toggle";
-import { useQuery } from "@tanstack/react-query";
-import { lordsInfoQueryOptions } from "@/lib/query-options";
 import { useNavigate, Link, useLocation } from "@tanstack/react-router";
 import { cn } from "@/lib/utils";
 import { Menu } from "lucide-react";
@@ -17,31 +13,18 @@ import {
 } from "@/components/ui/dropdown-menu";
 
 export function TopBar() {
-  const [time, setTime] = useState(new Date());
   const [isScrolled, setIsScrolled] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
   const { scrollY } = useScroll();
 
-  // Transform values for smooth transitions
-  const marginTop = useTransform(scrollY, [0, 50], [16, 0]);
-  const marginX = useTransform(scrollY, [0, 50], [16, 0]);
-  const paddingY = useTransform(scrollY, [0, 50], [16, 8]);
-
-  const { data: lordsInfo } = useQuery(lordsInfoQueryOptions());
-
-  const lordsPrice = lordsInfo?.price?.rate;
-
-  useEffect(() => {
-    const timer = setInterval(() => {
-      setTime(new Date());
-    }, 1000);
-    return () => clearInterval(timer);
-  }, []);
+  const marginTop = useTransform(scrollY, [0, 56], [14, 2]);
+  const marginX = useTransform(scrollY, [0, 56], [14, 0]);
+  const paddingY = useTransform(scrollY, [0, 56], [14, 10]);
 
   useEffect(() => {
     const handleScroll = () => {
-      setIsScrolled(window.scrollY > 10);
+      setIsScrolled(window.scrollY > 20);
     };
 
     window.addEventListener("scroll", handleScroll);
@@ -52,38 +35,49 @@ export function TopBar() {
     navigate({ to: "/" });
   };
 
-  // Page sections for navigation (only show on homepage)
   const pageSections =
     location.pathname === "/"
       ? [
           { id: "hero", label: "Home", href: "#" },
+          {
+            id: "agent-native",
+            label: "Agent Native",
+            href: "#agent-native",
+          },
+          {
+            id: "ecosystem-atlas",
+            label: "Ecosystem Atlas",
+            href: "#ecosystem-atlas",
+          },
           { id: "partners", label: "Partners", href: "#partners" },
           { id: "value-flow", label: "Value Flow", href: "#value-flow" },
           { id: "tokenomics", label: "Tokenomics", href: "#tokenomics" },
           { id: "treasury", label: "Treasury", href: "#treasury" },
         ]
       : [];
+  const railSections = pageSections.filter((section) => section.id !== "hero");
 
   const scrollToSection = (href: string) => {
     if (href === "#") {
       window.scrollTo({ top: 0, behavior: "smooth" });
-    } else {
-      const element = document.querySelector(href);
-      if (element) {
-        const offset = 100; // Account for fixed header
-        const elementPosition = element.getBoundingClientRect().top;
-        const offsetPosition = elementPosition + window.pageYOffset - offset;
-
-        window.scrollTo({
-          top: offsetPosition,
-          behavior: "smooth",
-        });
-      }
+      return;
     }
+
+    const element = document.querySelector(href);
+    if (!element) return;
+
+    const offset = 108;
+    const elementPosition = element.getBoundingClientRect().top;
+    const offsetPosition = elementPosition + window.pageYOffset - offset;
+
+    window.scrollTo({
+      top: offsetPosition,
+      behavior: "smooth",
+    });
   };
 
   return (
-    <motion.div
+    <motion.header
       className="fixed top-0 left-0 right-0 z-50"
       style={{
         marginTop: isScrolled ? 0 : marginTop,
@@ -91,10 +85,11 @@ export function TopBar() {
         marginRight: isScrolled ? 0 : marginX,
       }}
     >
-      <Card
+      <div
         className={cn(
-          "backdrop-blur-md transition-all duration-300",
-          isScrolled ? "rounded-none border-x-0 border-t-0" : ""
+          "border border-primary/25 bg-black/45 backdrop-blur-xl transition-all duration-300",
+          "supports-[backdrop-filter]:bg-black/35",
+          isScrolled ? "rounded-none border-x-0 border-t-0" : "rounded-2xl"
         )}
       >
         <motion.div
@@ -103,193 +98,97 @@ export function TopBar() {
             paddingBottom: isScrolled ? 8 : paddingY,
           }}
         >
-          <CardContent className="py-0">
-            <div className="container mx-auto px-2 sm:px-4">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center space-x-2 sm:space-x-8">
-                  <h1
-                    className="cursor-pointer text-primary transition-all"
-                    onClick={handleTitleClick}
-                  >
-                    <img
-                      src="/rw-logo.svg"
-                      alt="Realms.World"
-                      className={cn(
-                        "transition-all duration-300",
-                        isScrolled ? "w-10 sm:w-12" : "w-14 sm:w-18"
-                      )}
-                    />
-                  </h1>
+          <div className="container mx-auto px-3 sm:px-4">
+            <div className="flex items-center justify-between gap-2 sm:gap-4">
+              <button
+                className="flex items-center gap-2 sm:gap-3 text-left"
+                onClick={handleTitleClick}
+                aria-label="Go to homepage"
+              >
+                <img
+                  src="/rw-logo.svg"
+                  alt="Realms.World"
+                  className={cn(
+                    "transition-all duration-300",
+                    isScrolled ? "w-10 sm:w-11" : "w-12 sm:w-14"
+                  )}
+                />
+              </button>
 
-                  {/* Navigation Links */}
-                  <nav className="flex items-center space-x-3 sm:space-x-4">
-                    {/* Always show Games link */}
-                    <Link
-                      to="/games"
-                      className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors"
-                      activeProps={{
-                        className: "text-primary",
-                      }}
-                    >
-                      Games
-                    </Link>
-                    <Link
-                      to="/scroll"
-                      className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors"
-                      activeProps={{
-                        className: "text-primary",
-                      }}
-                    >
-                      Scroll
-                    </Link>
+              <nav className="hidden xl:flex items-center gap-3">
+                <Link
+                  to="/games"
+                  className="text-xs uppercase tracking-[0.15em] text-foreground/75 hover:text-primary transition-colors"
+                  activeProps={{
+                    className: "text-primary",
+                  }}
+                >
+                  Games
+                </Link>
+                <Link
+                  to="/scroll"
+                  className="text-xs uppercase tracking-[0.15em] text-foreground/75 hover:text-primary transition-colors"
+                  activeProps={{
+                    className: "text-primary",
+                  }}
+                >
+                  Scroll
+                </Link>
+              </nav>
 
-                    {/* Show section links on homepage */}
-                    {pageSections.length > 0 && (
-                      <>
-                        <span className="h-4 w-px bg-border" />
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              className="lg:hidden px-2"
-                              aria-label="Open section navigation"
-                            >
-                              <Menu className="h-4 w-4" />
-                              <span className="ml-1">Sections</span>
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="start" className="w-44">
-                            {pageSections.map((section) => (
-                              <DropdownMenuItem
-                                key={section.id}
-                                onSelect={(event) => {
-                                  event.preventDefault();
-                                  scrollToSection(section.href);
-                                }}
-                              >
-                                {section.label}
-                              </DropdownMenuItem>
-                            ))}
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                        {pageSections.slice(1).map((section) => (
-                          <button
-                            key={section.id}
-                            onClick={() => scrollToSection(section.href)}
-                            className={cn(
-                              "text-sm font-medium text-muted-foreground hover:text-primary transition-colors",
-                              "hidden lg:block"
-                            )}
-                          >
-                            {section.label}
-                          </button>
-                        ))}
-                      </>
-                    )}
-                  </nav>
-
-                  <div className="hidden sm:flex items-center space-x-2 text-muted-foreground">
-                    <span
-                      className={cn(
-                        "transition-all duration-300",
-                        isScrolled ? "text-xs" : "text-xs sm:text-sm"
-                      )}
-                    >
-                      {time.toLocaleTimeString([], {
-                        hour: "2-digit",
-                        minute: "2-digit",
-                      })}
-                    </span>
-                    <span className="h-4 w-px bg-border" />
-                    <motion.div
-                      className="flex items-center space-x-1"
-                      initial={{ opacity: 0, x: -20 }}
-                      animate={{ opacity: 1, x: 0 }}
-                      transition={{ delay: 0.5 }}
-                    >
-                      <span
-                        className={cn(
-                          "transition-all duration-300",
-                          isScrolled ? "text-xs" : "text-xs sm:text-sm"
-                        )}
-                      >
-                        LORDS:
-                      </span>
-                      <span
-                        className={cn(
-                          "transition-all duration-300",
-                          isScrolled ? "text-xs" : "text-xs sm:text-sm"
-                        )}
-                      >
-                        ${lordsPrice?.toLocaleString()}
-                      </span>
-                    </motion.div>
-                  </div>
-                </div>
-
-                <div className="flex items-center space-x-2 sm:space-x-6">
-                  {/* Social Links */}
-                  <div
-                    className={cn(
-                      "items-center space-x-4",
-                      isScrolled ? "hidden xl:flex" : "hidden sm:flex"
-                    )}
-                  >
-                    {socials.map((social) => (
-                      <a
-                        key={social.id}
-                        href={social.href}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-muted-foreground hover:text-primary transition-colors"
-                      >
-                        <svg
-                          viewBox="0 0 24 24"
-                          className={cn(
-                            "fill-current transition-all duration-300",
-                            isScrolled ? "w-4 h-4" : "w-5 h-5"
-                          )}
-                          aria-hidden="true"
-                        >
-                          <path d={social.icon} />
-                        </svg>
-                        <span className="sr-only">{social.name}</span>
-                      </a>
-                    ))}
-                  </div>
-                  <span
-                    className={cn(
-                      "h-6 w-px bg-border",
-                      isScrolled ? "hidden xl:block" : "hidden sm:block"
-                    )}
-                  />
-
-                  {/* Auth Buttons */}
-                  <div className="flex items-center space-x-2 sm:space-x-4">
-                    <a
-                      href="https://account.realms.world/"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
+              <div className="flex items-center gap-2 sm:gap-3">
+                {pageSections.length > 0 && (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
                       <Button
+                        variant="ghost"
                         size="sm"
-                        className={cn(
-                          "cursor-pointer transition-all duration-300",
-                          isScrolled ? "text-xs px-3" : ""
-                        )}
+                        className="lg:hidden px-2"
+                        aria-label="Open section navigation"
                       >
-                        Log In
+                        <Menu className="h-4 w-4" />
+                        <span className="ml-1">Sections</span>
                       </Button>
-                    </a>
-                    <ModeToggle />
-                  </div>
-                </div>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="w-52">
+                      {pageSections.map((section) => (
+                        <DropdownMenuItem
+                          key={section.id}
+                          onSelect={(event) => {
+                            event.preventDefault();
+                            scrollToSection(section.href);
+                          }}
+                        >
+                          {section.label}
+                        </DropdownMenuItem>
+                      ))}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )}
+
+                <ModeToggle />
               </div>
             </div>
-          </CardContent>
+          </div>
         </motion.div>
-      </Card>
-    </motion.div>
+      </div>
+
+      {railSections.length > 0 ? (
+        <aside
+          aria-label="Section rail navigation"
+          className="fixed right-3 top-1/2 -translate-y-1/2 z-40 hidden lg:flex flex-col gap-2"
+        >
+          {railSections.map((section) => (
+            <button
+              key={section.id}
+              onClick={() => scrollToSection(section.href)}
+              className="rounded-md border border-primary/25 bg-black/45 px-3 py-2 text-[11px] uppercase tracking-[0.16em] text-foreground/80 hover:text-primary hover:border-primary/60 transition-colors text-right"
+            >
+              {section.label}
+            </button>
+          ))}
+        </aside>
+      ) : null}
+    </motion.header>
   );
 }

--- a/src/components/sections/AgentNativeSection.tsx
+++ b/src/components/sections/AgentNativeSection.tsx
@@ -1,0 +1,84 @@
+import { motion } from "framer-motion";
+import { Bot, Compass, Workflow, ShieldCheck } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Link } from "@tanstack/react-router";
+
+const pillars = [
+  {
+    icon: Compass,
+    title: "Discover",
+    copy: "The agent reads each game's state and identifies the strongest available path.",
+  },
+  {
+    icon: Workflow,
+    title: "Execute",
+    copy: "From tactical turns to resource flows, actions are orchestrated with speed and consistency.",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Adapt",
+    copy: "As the ecosystem evolves, the agent updates its playbook and rolls out game by game.",
+  },
+];
+
+export function AgentNativeSection() {
+  return (
+    <section className="relative py-20 sm:py-24">
+      <div className="absolute inset-0 -z-10">
+        <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/40 to-transparent" />
+        <div className="absolute right-[-8%] top-1/2 -translate-y-1/2 h-52 w-52 rounded-full bg-primary/20 blur-3xl" />
+      </div>
+
+      <div className="container mx-auto px-4">
+        <motion.div
+          className="grid grid-cols-1 lg:grid-cols-[1.2fr_1fr] gap-8 lg:gap-12 items-start"
+          initial={{ opacity: 0, y: 22 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+        >
+          <div className="rounded-2xl border border-primary/25 bg-black/30 backdrop-blur-md p-6 sm:p-8">
+            <p className="text-xs uppercase tracking-[0.22em] text-primary/90 mb-4">
+              Agent Native
+            </p>
+            <h2 className="font-serif text-3xl sm:text-4xl md:text-5xl leading-tight mb-5">
+              One Agent,
+              <span className="text-primary"> Every Realm.</span>
+            </h2>
+            <p className="text-base sm:text-lg text-foreground/80 max-w-2xl mb-7">
+              We are launching an autonomous game agent for Realms players and
+              rolling it out across games. It scouts state, acts decisively, and
+              keeps improving as the ecosystem expands.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <Button size="lg" asChild>
+                <Link to="/games">
+                  <Bot className="mr-2 h-4 w-4" />
+                  Explore Ecosystem
+                </Link>
+              </Button>
+              <Button size="lg" variant="outline" asChild>
+                <a href="#ecosystem-atlas">View Live Atlas</a>
+              </Button>
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            {pillars.map((pillar, index) => (
+              <motion.article
+                key={pillar.title}
+                className="rounded-2xl border border-primary/20 bg-black/25 p-5"
+                initial={{ opacity: 0, x: 16 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ delay: 0.1 + index * 0.1, duration: 0.45 }}
+              >
+                <pillar.icon className="h-5 w-5 text-primary mb-3" />
+                <h3 className="text-xl font-semibold mb-2">{pillar.title}</h3>
+                <p className="text-foreground/75">{pillar.copy}</p>
+              </motion.article>
+            ))}
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/EcosystemAtlasSection.tsx
+++ b/src/components/sections/EcosystemAtlasSection.tsx
@@ -1,0 +1,76 @@
+import { motion } from "framer-motion";
+import { games } from "@/data/games";
+import { Link } from "@tanstack/react-router";
+import { ArrowUpRight } from "lucide-react";
+
+const atlasGames = games.slice(0, 8);
+const liveCount = games.filter((game) => game.isLive).length;
+
+export function EcosystemAtlasSection() {
+  return (
+    <section className="relative py-20 sm:py-24">
+      <div className="absolute inset-0 -z-10">
+        <div className="absolute left-[15%] top-0 h-32 w-32 rounded-full bg-primary/20 blur-3xl" />
+      </div>
+
+      <div className="container mx-auto px-4">
+        <motion.div
+          className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-5 mb-10"
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+        >
+          <div>
+            <p className="text-xs uppercase tracking-[0.2em] text-primary/90 mb-3">
+              Ecosystem Atlas
+            </p>
+            <h2 className="font-serif text-3xl sm:text-4xl md:text-5xl">
+              Live Games, Linked Worlds
+            </h2>
+          </div>
+          <div className="rounded-xl border border-primary/30 bg-black/30 px-4 py-3">
+            <p className="text-xs uppercase tracking-[0.14em] text-primary/90">
+              Live Right Now
+            </p>
+            <p className="text-3xl font-bold">{liveCount}</p>
+          </div>
+        </motion.div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+          {atlasGames.map((game, index) => (
+            <motion.article
+              key={game.slug}
+              className="group relative overflow-hidden rounded-2xl border border-primary/20 bg-black/25 backdrop-blur-sm min-h-[220px]"
+              initial={{ opacity: 0, y: 26 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.08 * index, duration: 0.45 }}
+            >
+              <img
+                src={game.image}
+                alt={game.title}
+                className="absolute inset-0 h-full w-full object-cover opacity-60 transition-transform duration-500 group-hover:scale-105"
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-black via-black/30 to-transparent" />
+              <div className="relative p-5 flex h-full flex-col justify-end">
+                <p className="text-xs uppercase tracking-[0.16em] text-primary/90 mb-2">
+                  {game.isLive ? "Live Realm" : "Realm In Forging"}
+                </p>
+                <h3 className="text-xl font-semibold mb-3">{game.title}</h3>
+                <p className="text-sm text-foreground/75 mb-4 line-clamp-2">
+                  {game.description}
+                </p>
+                <Link
+                  to="/games/$slug"
+                  params={{ slug: game.slug }}
+                  className="inline-flex items-center text-sm text-primary hover:text-primary/80 transition-colors"
+                >
+                  Enter Realm <ArrowUpRight className="ml-1.5 h-4 w-4" />
+                </Link>
+              </div>
+            </motion.article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/GamesSection.tsx
+++ b/src/components/sections/GamesSection.tsx
@@ -24,16 +24,20 @@ export function GamesSection() {
   };
 
   return (
-    <section className="relative z-10 transition-all duration-500 mt-6 sm:mt-8 md:mt-20">
+    <section className="relative z-10 transition-all duration-500 mt-6 sm:mt-8 md:mt-20 py-8 sm:py-12">
       <div className="container mx-auto px-1 sm:px-2 md:px-4 mb-3 sm:mb-4 md:mb-8">
         <motion.h2
-          className="text-lg sm:text-xl md:text-2xl font-bold mb-1 sm:mb-2 md:mb-4"
+          className="font-serif text-2xl sm:text-3xl md:text-4xl font-bold mb-1 sm:mb-2 md:mb-3"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5 }}
         >
-          Featured Games
+          Realms To Conquer
         </motion.h2>
+        <p className="text-sm sm:text-base text-foreground/75">
+          Explore the live and emerging worlds where the agent is rolling out
+          across games.
+        </p>
       </div>
       <motion.div
         className="relative"

--- a/src/components/sections/IntroSection.tsx
+++ b/src/components/sections/IntroSection.tsx
@@ -1,9 +1,10 @@
 import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
-import { ArrowRight, Coins, Shield, Zap } from "lucide-react";
+import { ArrowRight, Coins, Sparkles, Sword, Zap } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import { useVelords } from "@/hooks/use-velords";
 import { StarknetProvider } from "@/hooks/starknet-provider";
+import { games } from "@/data/games";
 
 export function IntroSection() {
   return (
@@ -14,100 +15,105 @@ export function IntroSection() {
 }
 
 function IntroSectionContent() {
-  const { currentAPY, isAPYLoading, tvl, isTVLLoading, lordsLocked } =
-    useVelords();
+  const { currentAPY, isAPYLoading, tvl, isTVLLoading } = useVelords();
+  const liveGameCount = games.filter((game) => game.isLive).length;
 
-  const stats = [
+  const heroStats = [
     {
-      icon: Shield,
-      label: "Total Value Locked",
-      value: tvl
-        ? `$${tvl.toLocaleString(undefined, { maximumFractionDigits: 0 })}`
-        : isTVLLoading
-        ? "Loading..."
-        : "N/A",
-      description: lordsLocked
-        ? `${lordsLocked.toLocaleString(undefined, {
-            maximumFractionDigits: 0,
-          })} LORDS`
-        : "In veLORDS",
+      icon: Sword,
+      label: "Live Game Count",
+      value: liveGameCount.toString(),
+      detail: "Realms currently playable",
+    },
+    {
+      icon: Sparkles,
+      label: "Agent Rollout",
+      value: "Active",
+      detail: "Rolling out across games",
     },
     {
       icon: Coins,
+      label: "Ecosystem TVL",
+      value: tvl
+        ? `$${tvl.toLocaleString(undefined, { maximumFractionDigits: 0 })}`
+        : isTVLLoading
+        ? "Syncing..."
+        : "N/A",
+      detail: "Locked via veLORDS",
+    },
+    {
+      icon: Zap,
       label: "Current APY",
       value: currentAPY
         ? `${currentAPY.toFixed(2)}%`
         : isAPYLoading
-        ? "Loading..."
+        ? "Syncing..."
         : "N/A",
-      description: "Annual rewards",
-    },
-    {
-      icon: Zap,
-      label: "Active Games",
-      value: "6",
-      description: "In ecosystem",
+      detail: "Annual rewards",
     },
   ];
 
   return (
-    <section className="relative overflow-hidden bg-gradient-to-b from-background to-background/80 py-20 md:py-32">
-      {/* Background decoration */}
+    <section className="relative overflow-hidden py-18 sm:py-24 md:py-32">
       <div className="absolute inset-0 -z-10">
-        <div className="absolute left-1/2 top-0 -translate-x-1/2 -translate-y-1/2 h-[600px] w-[600px] rounded-full bg-primary/10 blur-3xl" />
-        <div className="absolute right-0 bottom-0 translate-x-1/2 translate-y-1/2 h-[400px] w-[400px] rounded-full bg-primary/5 blur-3xl" />
+        <div className="absolute left-1/2 top-12 -translate-x-1/2 h-[360px] w-[95%] max-w-6xl rounded-full bg-primary/20 blur-3xl" />
+        <div className="absolute left-1/2 top-16 -translate-x-1/2 h-[520px] w-[92%] max-w-6xl border border-primary/30 rounded-[999px] opacity-55" />
       </div>
 
       <div className="container mx-auto px-4">
         <motion.div
-          className="text-center max-w-4xl mx-auto mb-16"
-          initial={{ opacity: 0, y: 20 }}
+          className="max-w-5xl mx-auto text-center"
+          initial={{ opacity: 0, y: 24 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8 }}
+          transition={{ duration: 0.7 }}
         >
-          <h1 className="text-4xl md:text-6xl font-bold mb-6 bg-gradient-to-r from-primary to-primary/60 bg-clip-text text-transparent">
-            terraforming onchain worlds
-          </h1>
-          <p className="text-xl text-muted-foreground mb-8">
-            The premier onchain gaming ecosystem built on Starknet. Play games,
-            earn rewards, and participate in the future of onchain gaming.
+          <p className="inline-flex items-center gap-2 text-xs tracking-[0.28em] uppercase text-primary/90 mb-6">
+            <Sparkles className="h-3.5 w-3.5" />
+            Agent Native Games
           </p>
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Button size="lg" asChild>
+          <h1 className="font-serif text-4xl sm:text-5xl md:text-7xl leading-[0.95] tracking-tight text-foreground mb-6">
+            Mythic Worlds.
+            <span className="block text-primary">One Autonomous Champion.</span>
+          </h1>
+          <p className="text-base sm:text-lg md:text-xl text-foreground/85 max-w-3xl mx-auto mb-10">
+            The Realms ecosystem is now agent-native. Our autonomous player is
+            rolling out across games so you can explore every realm with deeper
+            strategy and faster execution.
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-3 justify-center mb-14">
+            <Button size="lg" className="shadow-lg shadow-primary/20" asChild>
               <Link to="/games">
-                Explore Games <ArrowRight className="ml-2 h-4 w-4" />
+                Explore Ecosystem <ArrowRight className="ml-2 h-4 w-4" />
               </Link>
+            </Button>
+            <Button size="lg" variant="outline" asChild>
+              <a href="#agent-native">See Agent Rollout</a>
             </Button>
           </div>
         </motion.div>
 
-        {/* Stats Grid */}
         <motion.div
-          className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-4xl mx-auto"
+          className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 max-w-6xl mx-auto"
           initial={{ opacity: 0, y: 40 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.2 }}
+          transition={{ delay: 0.2, duration: 0.7 }}
         >
-          {stats.map((stat, index) => (
-            <motion.div
+          {heroStats.map((stat, index) => (
+            <motion.article
               key={stat.label}
-              className="relative group"
-              initial={{ opacity: 0, scale: 0.9 }}
-              animate={{ opacity: 1, scale: 1 }}
-              transition={{ duration: 0.5, delay: 0.3 + index * 0.1 }}
+              className="rounded-2xl border border-primary/20 bg-black/25 backdrop-blur-md p-5"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.25 + index * 0.1, duration: 0.45 }}
             >
-              <div className="absolute inset-0 bg-gradient-to-r from-primary/20 to-primary/10 rounded-lg blur-xl group-hover:blur-2xl transition-all" />
-              <div className="relative bg-card p-6 rounded-lg border border-border/50 hover:border-primary/50 transition-colors">
-                <stat.icon className="h-8 w-8 text-primary mb-4" />
-                <div className="text-3xl font-bold mb-1">{stat.value}</div>
-                <div className="text-sm font-medium text-muted-foreground mb-1">
-                  {stat.label}
-                </div>
-                <div className="text-xs text-muted-foreground">
-                  {stat.description}
-                </div>
-              </div>
-            </motion.div>
+              <stat.icon className="h-5 w-5 text-primary mb-4" />
+              <p className="text-3xl font-bold text-foreground mb-1">{stat.value}</p>
+              <p className="text-xs uppercase tracking-[0.14em] text-primary/90 mb-2">
+                {stat.label}
+              </p>
+              <p className="text-sm text-foreground/70">{stat.detail}</p>
+            </motion.article>
           ))}
         </motion.div>
       </div>

--- a/src/components/sections/PartnersSection.tsx
+++ b/src/components/sections/PartnersSection.tsx
@@ -1,87 +1,64 @@
 import { motion } from "framer-motion";
-
-// Partner data - replace with actual partner logos
-const partners = [
-  {
-    name: "Starknet",
-    logo: "/partners/Starknet.svg",
-    url: "https://starknet.io",
-  },
-  {
-    name: "Starkware",
-    logo: "/partners/Starkware.svg",
-    url: "https://starkware.co",
-  },
-  {
-    name: "Dojo",
-    logo: "/partners/dojo-logo.svg",
-    url: "https://dojoengine.org",
-  },
-  {
-    name: "Cartridge",
-    logo: "/partners/Cartridge.svg",
-    url: "https://cartridge.gg",
-  },
-];
+import { partners } from "@/data/partners";
 
 export function PartnersSection() {
   return (
-    <section className="py-16 sm:py-24 bg-background/50">
+    <section className="relative py-16 sm:py-20">
+      <div className="absolute inset-0 -z-10">
+        <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/40 to-transparent" />
+      </div>
+
       <div className="container mx-auto px-4">
         <motion.div
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
-          transition={{ duration: 0.8 }}
-          className="space-y-12"
+          transition={{ duration: 0.7 }}
+          className="space-y-10"
         >
-          {/* Header */}
           <motion.div
             className="text-center max-w-3xl mx-auto space-y-4"
             initial={{ y: -20, opacity: 0 }}
             animate={{ y: 0, opacity: 1 }}
-            transition={{ delay: 0.2, duration: 0.8 }}
+            transition={{ delay: 0.15, duration: 0.7 }}
           >
-            <h2 className="text-3xl sm:text-4xl font-bold">Trusted Partners</h2>
-            <p className="text-lg text-muted-foreground">
-              Building the future of onchain gaming together with industry
-              leaders
+            <p className="text-xs uppercase tracking-[0.2em] text-primary/90">
+              Allied Infrastructure
+            </p>
+            <h2 className="font-serif text-3xl sm:text-4xl md:text-5xl">
+              Built With Core Partners
+            </h2>
+            <p className="text-base sm:text-lg text-foreground/75">
+              Realms operates with the core protocols and teams powering
+              onchain worlds.
             </p>
           </motion.div>
 
-          {/* Partners Grid */}
           <motion.div
-            className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-8 items-center"
+            className="grid grid-cols-2 md:grid-cols-4 gap-4 sm:gap-6 items-stretch"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
-            transition={{ delay: 0.4, duration: 0.8 }}
+            transition={{ delay: 0.3, duration: 0.7 }}
           >
             {partners.map((partner, index) => (
               <motion.a
-                key={partner.name}
+                key={partner.id}
                 href={partner.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="group flex items-center justify-center p-6 rounded-lg bg-background border border-border/50 hover:border-primary/50 transition-all duration-300 hover:shadow-lg"
+                className="group flex flex-col items-center justify-center rounded-xl border border-primary/20 bg-black/30 px-4 py-6 sm:py-8 hover:border-primary/50 transition-colors"
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.5 + index * 0.1, duration: 0.6 }}
-                whileHover={{ scale: 1.05 }}
+                transition={{ delay: 0.35 + index * 0.08, duration: 0.45 }}
+                whileHover={{ y: -2 }}
               >
                 <img
                   src={partner.logo}
                   alt={partner.name}
-                  className="h-8 w-auto object-contain filter grayscale group-hover:grayscale-0 transition-all duration-300 opacity-60 group-hover:opacity-100"
-                  onError={(e) => {
-                    // Fallback to text if logo doesn't load
-                    const target = e.target as HTMLImageElement;
-                    target.style.display = "none";
-                    const textFallback = document.createElement("div");
-                    textFallback.className =
-                      "text-lg font-semibold text-muted-foreground group-hover:text-primary transition-colors";
-                    textFallback.textContent = partner.name;
-                    target.parentElement?.appendChild(textFallback);
-                  }}
+                  className="h-8 sm:h-10 w-auto object-contain grayscale opacity-70 group-hover:grayscale-0 group-hover:opacity-100 transition-all"
                 />
+                <span className="mt-3 text-xs uppercase tracking-[0.14em] text-foreground/70 group-hover:text-primary transition-colors">
+                  {partner.name}
+                </span>
               </motion.a>
             ))}
           </motion.div>

--- a/src/components/sections/ValueFlowSection.tsx
+++ b/src/components/sections/ValueFlowSection.tsx
@@ -55,7 +55,7 @@ const VALUE_SOURCES = [
   {
     id: "games",
     label: "Ecosystem Games",
-    description: "Loot Survivor, Blobert Arena, and more",
+    description: "Loot Survivor, Blob Arena, and more",
     icon: Gamepad2,
     value: "Game Fees",
     color: "border-purple-500/50",

--- a/src/data/partners.ts
+++ b/src/data/partners.ts
@@ -2,21 +2,25 @@ export const partners = [
   {
     id: 1,
     name: "Starknet",
-    logo: "/Starknet.svg",
+    logo: "/partners/Starknet.svg",
+    url: "https://starknet.io",
   },
   {
     id: 2,
     name: "Starkware",
-    logo: "/Starkware.svg",
+    logo: "/partners/Starkware.svg",
+    url: "https://starkware.co",
   },
   {
     id: 3,
     name: "Cartridge",
-    logo: "/Cartridge.svg",
+    logo: "/partners/Cartridge.svg",
+    url: "https://cartridge.gg",
   },
   {
     id: 4,
     name: "Dojo",
-    logo: "/dojo-logo.svg",
+    logo: "/partners/dojo-logo.svg",
+    url: "https://dojoengine.org",
   },
 ];

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Source+Code+Pro:ital,wght@0,200..900;1,200..900&family=Space+Grotesk:wght@300..700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400..900&family=Manrope:wght@200..800&family=Source+Code+Pro:ital,wght@0,200..900;1,200..900&display=swap');
 
 @import 'tailwindcss';
 
@@ -38,8 +38,8 @@
   --sidebar-accent-foreground: oklch(0.33 0 0);
   --sidebar-border: oklch(0.94 0 0);
   --sidebar-ring: oklch(0.77 0 0);
-  --font-sans: Space Grotesk, serif;
-  --font-serif: Space Grotesk, serif;
+  --font-sans: Manrope, sans-serif;
+  --font-serif: Cinzel, serif;
   --font-mono: Source Code Pro, monospace;
   --radius: 0rem;
   --shadow-2xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
@@ -85,8 +85,8 @@
   --sidebar-accent-foreground: oklch(0.97 0.00 286.38);
   --sidebar-border: oklch(0.27 0.01 286.03);
   --sidebar-ring: oklch(0.87 0.01 286.29);
-  --font-sans: Space Grotesk, serif;
-  --font-serif: Space Grotesk, serif;
+  --font-sans: Manrope, sans-serif;
+  --font-serif: Cinzel, serif;
   --font-mono: Source Code Pro, monospace;
   --radius: 0rem;
   --shadow-2xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -18,6 +18,11 @@ const FooterSection = lazy(() =>
     default: module.FooterSection,
   }))
 );
+const RealmSceneBackground = lazy(() =>
+  import("@/components/RealmSceneBackground").then((module) => ({
+    default: module.RealmSceneBackground,
+  }))
+);
 
 function DeferredFooter() {
   const [isVisible, setIsVisible] = useState(false);
@@ -125,7 +130,11 @@ function RootComponent() {
       {/* <AsciiArt /> */}
       {/* Fixed position background */}
       <div className="fixed inset-0">
-        <div className="absolute inset-x-0 bottom-0 h-[70vh]" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_10%,rgba(246,194,122,0.17),transparent_42%),radial-gradient(circle_at_80%_8%,rgba(106,127,227,0.18),transparent_35%),linear-gradient(180deg,rgba(13,15,22,0.97),rgba(11,11,15,0.94))]" />
+        <Suspense fallback={null}>
+          <RealmSceneBackground />
+        </Suspense>
+        <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(8,8,11,0.06),rgba(8,8,11,0.35))]" />
       </div>
 
       {/* Scrollable content */}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,9 +3,14 @@ import { ReactNode, Suspense, lazy, useEffect, useRef, useState } from "react";
 import { IntroSection } from "@/components/sections/IntroSection";
 import { generateMetaTags } from "@/lib/og-image";
 
-const GamesSection = lazy(() =>
-  import("@/components/sections/GamesSection").then((module) => ({
-    default: module.GamesSection,
+const AgentNativeSection = lazy(() =>
+  import("@/components/sections/AgentNativeSection").then((module) => ({
+    default: module.AgentNativeSection,
+  }))
+);
+const EcosystemAtlasSection = lazy(() =>
+  import("@/components/sections/EcosystemAtlasSection").then((module) => ({
+    default: module.EcosystemAtlasSection,
   }))
 );
 const PartnersSection = lazy(() =>
@@ -81,9 +86,9 @@ export const Route = createFileRoute("/")({
   component: HomePage,
   head: () => ({
     meta: generateMetaTags({
-      title: "Realms World - Onchain Gaming Powered by $LORDS",
+      title: "Realms World - Agent-Native Onchain Gaming",
       description:
-        "The future of gaming is onchain. Explore games powered by $LORDS token in the Realms ecosystem.",
+        "Enter the mythic onchain gaming ecosystem where a Realms agent is rolling out across games. Explore live worlds powered by $LORDS.",
       path: "/",
     }),
   }),
@@ -95,9 +100,14 @@ function HomePage() {
       <div id="hero">
         <IntroSection />
       </div>
-      <div id="games">
+      <div id="agent-native">
         <DeferredSection eager>
-          <GamesSection />
+          <AgentNativeSection />
+        </DeferredSection>
+      </div>
+      <div id="ecosystem-atlas">
+        <DeferredSection eager>
+          <EcosystemAtlasSection />
         </DeferredSection>
       </div>
       <div id="partners">

--- a/tests/agent-native-overhaul.test.mjs
+++ b/tests/agent-native-overhaul.test.mjs
@@ -1,0 +1,150 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = process.cwd();
+
+function read(relPath) {
+  return readFileSync(join(ROOT, relPath), "utf8");
+}
+
+test("Homepage route includes agent-native and atlas section anchors", () => {
+  const homeRoute = read("src/routes/index.tsx");
+
+  assert.match(
+    homeRoute,
+    /id="agent-native"/,
+    "Expected homepage to include an agent-native section anchor"
+  );
+  assert.match(
+    homeRoute,
+    /id="ecosystem-atlas"/,
+    "Expected homepage to include an ecosystem-atlas section anchor"
+  );
+  assert.doesNotMatch(
+    homeRoute,
+    /id="games"/,
+    "Expected duplicate homepage games section to be removed"
+  );
+});
+
+test("Intro hero derives live game count from shared games data", () => {
+  const intro = read("src/components/sections/IntroSection.tsx");
+
+  assert.match(
+    intro,
+    /games\.filter\(\(game\) => game\.isLive\)\.length/,
+    "Expected live game count to be derived from the games dataset"
+  );
+});
+
+test("Agent rollout message is present in hero copy", () => {
+  const intro = read("src/components/sections/IntroSection.tsx");
+
+  assert.match(
+    intro,
+    /rolling out across games/i,
+    "Expected rollout wording in hero copy"
+  );
+});
+
+test("Header keeps only Games/Scroll while section links move to right rail", () => {
+  const topBar = read("src/components/layout/TopBar.tsx");
+
+  assert.match(
+    topBar,
+    /to="\/games"/,
+    "Expected header nav to keep Games link"
+  );
+  assert.match(
+    topBar,
+    /to="\/scroll"/,
+    "Expected header nav to keep Scroll link"
+  );
+  assert.match(
+    topBar,
+    /Section rail navigation/,
+    "Expected a right-side vertical section rail"
+  );
+  assert.match(
+    topBar,
+    /Agent Native/,
+    "Expected section rail to include Agent Native"
+  );
+  assert.match(
+    topBar,
+    /Ecosystem Atlas/,
+    "Expected section rail to include Ecosystem Atlas"
+  );
+  assert.doesNotMatch(
+    topBar,
+    /id:\s*"games",\s*label:\s*"Games",\s*href:\s*"#games"/,
+    "Expected header section anchors to drop removed duplicate games block"
+  );
+});
+
+test("Header style aligns with agent-native revamp", () => {
+  const topBar = read("src/components/layout/TopBar.tsx");
+
+  assert.match(
+    topBar,
+    /bg-black\/45/,
+    "Expected a darker mythic header surface"
+  );
+  assert.match(
+    topBar,
+    /Go to homepage/,
+    "Expected logo button to remain for homepage navigation"
+  );
+  assert.doesNotMatch(
+    topBar,
+    /Agent-native ecosystem/,
+    "Expected agent-native text block to be removed from header"
+  );
+  assert.doesNotMatch(
+    topBar,
+    /Explore Ecosystem/,
+    "Expected extra header CTA to be removed"
+  );
+  assert.doesNotMatch(
+    topBar,
+    /LORDS:/,
+    "Expected legacy LORDS ticker to be removed from header"
+  );
+});
+
+test("Background scene uses a Mobius strip centerpiece", () => {
+  const bg = read("src/components/RealmSceneBackground.tsx");
+
+  assert.match(
+    bg,
+    /createMobiusStripGeometry/,
+    "Expected explicit Mobius strip geometry generator"
+  );
+  assert.match(
+    bg,
+    /mobiusStrip/i,
+    "Expected Mobius strip mesh usage in scene composition"
+  );
+  assert.doesNotMatch(
+    bg,
+    /new THREE\.TorusGeometry\(2\.6, 0\.12, 24, 140\)/,
+    "Expected legacy torus centerpiece to be removed"
+  );
+});
+
+test("Partners section uses shared partner data source", () => {
+  const partnersSection = read("src/components/sections/PartnersSection.tsx");
+
+  assert.match(
+    partnersSection,
+    /from "@\/data\/partners"/,
+    "Expected partners section to consume shared data module"
+  );
+  assert.doesNotMatch(
+    partnersSection,
+    /const partners = \[/,
+    "Expected inline partner list duplication to be removed"
+  );
+});


### PR DESCRIPTION
This PR overhauls the homepage narrative and visuals around agent-native gaming. It adds a Three.js mythic background with a Mobius-strip centerpiece, introduces new Agent Native and Ecosystem Atlas sections, and streamlines header navigation with a right-side section rail. It also removes duplicate homepage game surfacing, unifies partner data usage, and tightens copy consistency. Validation passed with lint, build, and landing/mobile regression tests.