### PR TITLE
Fix build errors in landing page revamp

### DIFF
--- a/src/components/GamePillarSection.tsx
+++ b/src/components/GamePillarSection.tsx
@@ -57,7 +57,7 @@ const fadeUp = {
   visible: {
     opacity: 1,
     y: 0,
-    transition: { duration: 0.5, ease: "easeOut" },
+    transition: { duration: 0.5, ease: "easeOut" as const },
   },
 };
 
@@ -76,7 +76,7 @@ const centerHexVariant = {
   visible: {
     scale: 1,
     opacity: 1,
-    transition: { duration: 0.45, ease: "easeOut" },
+    transition: { duration: 0.45, ease: "easeOut" as const },
   },
 };
 
@@ -85,7 +85,7 @@ const surroundHexVariant = {
   visible: {
     scale: 1,
     opacity: 1,
-    transition: { duration: 0.35, ease: "easeOut" },
+    transition: { duration: 0.35, ease: "easeOut" as const },
   },
 };
 

--- a/src/components/hex-explorer/HexExplorerCanvas.tsx
+++ b/src/components/hex-explorer/HexExplorerCanvas.tsx
@@ -264,7 +264,7 @@ export function HexExplorerCanvas({
       if (!ctx) return;
       const s = stateRef.current;
       s.time = now;
-      const dt = 1 / 60; // normalized timestep
+
 
       const moveDuration = s.prefersReducedMotion ? 0 : 200; // ms
 


### PR DESCRIPTION
## Summary
- Fix framer-motion `Variants` type errors in `GamePillarSection.tsx` by adding `as const` to `ease: "easeOut"` (narrows `string` → `"easeOut"` literal to match the `Easing` union type)
- Remove unused `dt` variable in `HexExplorerCanvas.tsx` that caused `TS6133`

These two issues were causing the build to fail on both Vercel and Cloudflare.

## Test plan
- [x] `pnpm build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)