### PR TITLE
Update game listings and Loot Survivor URL

### DIFF
--- a/src/components/hex-explorer/feature-data.ts
+++ b/src/components/hex-explorer/feature-data.ts
@@ -29,16 +29,7 @@ export const FEATURE_HEXES: FeatureHexData[] = [
     label: "Loot Survivor",
     description:
       "Onchain roguelike with permadeath. Defeat beasts, collect gear, climb the leaderboard. The original Play2Die game with 1,250+ survivors.",
-    link: "https://survivor.realms.world/",
-  },
-  {
-    coord: { q: -4, r: 1 },
-    type: "game",
-    symbol: "DSH",
-    label: "Dark Shuffle",
-    description:
-      "Draft creatures and spells, venture through a map of challenges. Deck-building roguelike by Provable Games.",
-    link: "https://darkshuffle.io/",
+    link: "https://www.deathmountain.gg/lootsurvivor",
   },
   {
     coord: { q: 2, r: 3 },
@@ -48,15 +39,6 @@ export const FEATURE_HEXES: FeatureHexData[] = [
     description:
       "Onchain dueling where every bluff and bullet is etched forever. Challenge friends in atmospheric showdowns by Underware.",
     link: "https://pistols.gg",
-  },
-  {
-    coord: { q: 3, r: -5 },
-    type: "game",
-    symbol: "BLB",
-    label: "Blob Arena",
-    description:
-      "Turn-based combat where Bloberts clash using Attack, Defence, Speed, and Strength. Enhanced rock-paper-scissors by Grugs Lair.",
-    link: "https://www.blobarena.xyz/",
   },
   {
     coord: { q: -1, r: -4 },

--- a/src/components/sections/EcosystemAtlasSection.tsx
+++ b/src/components/sections/EcosystemAtlasSection.tsx
@@ -16,8 +16,6 @@ import { Button } from "@/components/ui/button";
 const homepageGameOrder = [
   "blitz",
   "loot-survivor",
-  "blob-arena",
-  "dark-shuffle",
   "zkube",
   "realms-eternum",
 ];

--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -127,7 +127,7 @@ export const games: Game[] = [
     studio: "Provable Games",
     players: 1250,
     links: {
-      homepage: "https://survivor.realms.world/",
+      homepage: "https://www.deathmountain.gg/lootsurvivor",
       discord: "https://discord.gg/realmsworld",
       twitter: "https://twitter.com/LootRealms",
     },

--- a/src/data/games/loot-survivor.mdoc
+++ b/src/data/games/loot-survivor.mdoc
@@ -25,10 +25,10 @@ screenshots:
   - screenshots/2.png
   - screenshots/3.png
 links:
-  homepage: https://survivor.realms.world/
+  homepage: https://www.deathmountain.gg/lootsurvivor
   discord: https://discord.gg/realmsworld
   twitter: https://twitter.com/LootRealms
-  mainnet: https://survivor.realms.world/
+  mainnet: https://www.deathmountain.gg/lootsurvivor
   testnet: https://beta-survivor.realms.world/
 playable: true
 ---

--- a/src/routes/games/index.tsx
+++ b/src/routes/games/index.tsx
@@ -23,11 +23,8 @@ const gamesDirectoryOrder = [
   "blitz",
   "realms-eternum",
   "loot-survivor",
-  "blob-arena",
-  "dark-shuffle",
   "zkube",
   "pistols-at-dawn",
-  "rising-revenant",
 ];
 
 function orderGames(games: Game[]) {
@@ -65,8 +62,8 @@ function GamesPage() {
   const orderedGames = orderGames(games);
   const featuredGame = orderedGames[0];
   const secondaryGames = orderedGames.slice(1);
-  const liveGamesCount = games.filter((game) => game.isLive).length;
-  const studiosCount = new Set(games.map((game) => game.studio)).size;
+  const liveGamesCount = orderedGames.filter((game) => game.isLive).length;
+  const studiosCount = new Set(orderedGames.map((game) => game.studio)).size;
 
   return (
     <section className="realm-section realm-games-stage relative overflow-hidden py-10 sm:py-14">
@@ -90,7 +87,7 @@ function GamesPage() {
                 </p>
               </div>
               <div className="flex gap-2 sm:gap-3">
-                <span className="realm-sigil">{games.length} games listed</span>
+                <span className="realm-sigil">{orderedGames.length} games listed</span>
               </div>
             </div>
             <div className="realm-games-metrics mt-5 sm:!grid-cols-2">


### PR DESCRIPTION
## Summary
- replace the old Loot Survivor URL with `https://www.deathmountain.gg/lootsurvivor`
- remove Blob Arena and Dark Shuffle from the homepage game surfaces and Games directory
- remove Rising Revenant from the Games directory
- retain zKube in the homepage and Games directory
- calculate directory totals from the displayed games

## Validation
- production build passes
- ESLint passes
- browser-verified the homepage and `/games` directory

## Notes
- underlying detail content and assets remain available; this PR only changes the requested listings